### PR TITLE
fix(npm): 更新npm的package.json路径，调整npm默认下载源为淘宝源

### DIFF
--- a/nodehandle/npm.go
+++ b/nodehandle/npm.go
@@ -24,9 +24,11 @@ import (
 )
 
 const (
-	LATNPMURL  = "https://raw.githubusercontent.com/npm/npm/master/package.json"
+	LATNPMURL  = "https://raw.githubusercontent.com/npm/cli/latest/package.json"
 	NPMTAOBAO  = "http://npm.taobao.org/mirrors/npm/"
-	NPMDEFAULT = "https://github.com/npm/npm/releases/"
+	// use net/http, http.get(url), to download the github releases, failed. and curl.New() return error code -4 
+	// but taobao is fine, so I change the default to taobao to avoid reporting errors
+	NPMDEFAULT = "http://npm.taobao.org/mirrors/npm/"
 	ZIP        = ".zip"
 )
 


### PR DESCRIPTION
**更新npm的package.json路径**

npm仓库变更，调整package.json请求路径为`https://raw.githubusercontent.com/npm/cli/latest/package.json`

**调整npm默认下载源为淘宝源**

测试发现
* 请求github中的releases时，curl.New()，返回-4，得到的是一个空文件
* 但是使用淘宝时正常

因为不是很了解Go，所以就简单将默认下载源的改为淘宝源，来避免报错

issue #25 